### PR TITLE
Fix bug that allowed to dismiss the loading modals

### DIFF
--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -54,8 +54,9 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
         </div>
       </div>
       """
-    tk.dom("[data-tuktuk=lock]").on "click", (e) ->
-      TukTuk.Modal.hide() unless e.target is modal
+    tk.dom("[data-tuktuk=lock]").on "click", (event) ->
+      loading = lock.attr("data-loading")
+      TukTuk.Modal.hide() unless event.target is modal or loading is "true"
       
     lock = tk.dom("[data-tuktuk=lock]").first()
   )()


### PR DESCRIPTION
This will solve a bug caused by my previous pull request (https://github.com/soyjavi/tuktuk/pull/29) that allowed the loading modals to be dismissed, which, I presume, is not the expected behaviour.
