### PR TITLE
Added named colors. And some minor changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+site/package

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 
 More info in http://tuktuk.tapquo.com , [Source code](https://github.com/soyjavi/tuktuk) and [issue tracking](https://github.com/soyjavi/tuktuk/issues) are available on Github.
 
+### Building
+
+You must have `nodejs` installed. It's a requirement to proceed with building.
+
+Now, to build the TukTuk sources, first run `[sudo] npm install`. This will install all the dependencies.
+Then run `grunt`. This will compile tuktuk sources to `site/package` directory.
+
 ## Credits
 Created by [Javier Jiménez](http://twitter.com/soyjavi).
 Copyright (c) 2011, 2013

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+  	"grunt-cli": "latest",
+  	"coffee": "latest",
+  	"grunt-contrib-coffee": "latest",
+  	"grunt-contrib-stylus": "latest",
+  	"grunt-contrib-copy": "latest",
+  	"grunt-contrib-watch": "latest"
+  }
+}

--- a/sources/stylesheets/tuktuk.button.styl
+++ b/sources/stylesheets/tuktuk.button.styl
@@ -13,6 +13,7 @@
   text-decoration: none
   outline: none
   background: none
+  margin: 0 2px
 
   &.icon
     padding: 0 0.65em

--- a/sources/stylesheets/tuktuk.colors.styl
+++ b/sources/stylesheets/tuktuk.colors.styl
@@ -1,0 +1,883 @@
+
+.color.aliceblue
+    color  #f0f8ff
+
+.color.antiquewhite
+    color  #faebd7
+
+.color.aqua
+    color  #00ffff
+
+.color.aquamarine
+    color  #7fffd4
+
+.color.azure
+    color  #f0ffff
+
+.color.beige
+    color  #f5f5dc
+
+.color.bisque
+    color  #ffe4c4
+
+.color.black
+    color  #000000
+
+.color.blanchedalmond
+    color  #ffebcd
+
+.color.blue
+    color  #0000ff
+
+.color.blueviolet
+    color  #8a2be2
+
+.color.brown
+    color  #a52a2a
+
+.color.burlywood
+    color  #deb887
+
+.color.cadetblue
+    color  #5f9ea0
+
+.color.chartreuse
+    color  #7fff00
+
+.color.chocolate
+    color  #d2691e
+
+.color.coral
+    color  #ff7f50
+
+.color.cornflowerblue
+    color  #6495ed
+
+.color.cornsilk
+    color  #fff8dc
+
+.color.crimson
+    color  #dc143c
+
+.color.cyan
+    color  #00ffff
+
+.color.darkblue
+    color  #00008b
+
+.color.darkcyan
+    color  #008b8b
+
+.color.darkgoldenrod
+    color  #b8840b
+
+.color.darkgray
+    color  #a9a9a9
+
+.color.darkgreen
+    color  #006400
+
+.color.darkgrey
+    color  #a9a9a9
+
+.color.darkkhaki
+    color  #bdb76b
+
+.color.darkmagenta
+    color  #8b008b
+
+.color.darkolivegreen
+    color  #556b2f
+
+.color.darkorange
+    color  #ff8c00
+
+.color.darkorchid
+    color  #9932cc
+
+.color.darkred
+    color  #8b0000
+
+.color.darksalmon
+    color  #e9967a
+
+.color.darkseagreen
+    color  #8fbc8f
+
+.color.darkslateblue
+    color  #483d8b
+
+.color.darkslategray
+    color  #2f4f4f
+
+.color.darkslategrey
+    color  #2f4f4f
+
+.color.darkturquoise
+    color  #00ced1
+
+.color.darkviolet
+    color  #9400d3
+
+.color.deeppink
+    color  #ff1493
+
+.color.deepskyblue
+    color  #00bfff
+
+.color.dimgray
+    color  #696969
+
+.color.dimgrey
+    color  #696969
+
+.color.dodgerblue
+    color  #1e90ff
+
+.color.firebrick
+    color  #b22222
+
+.color.floralwhite
+    color  #fffff0
+
+.color.forestgreen
+    color  #228b22
+
+.color.fuchsia
+    color  #ff00ff
+
+.color.gainsboro
+    color  #dcdcdc
+
+.color.ghostwhite
+    color  #f8f8ff
+
+.color.gold
+    color  #ffd700
+
+.color.goldenrod
+    color  #daa520
+
+.color.gray
+    color  #808080
+
+.color.green
+    color  #008000
+
+.color.greenyellow
+    color  #adff2f
+
+.color.grey
+    color  #808080
+
+.color.honeydew
+    color  #f0fff0
+
+.color.hotpink
+    color  #ff69b4
+
+.color.indianred
+    color  #cd5c5c
+
+.color.indigo
+    color  #4b0082
+
+.color.ivory
+    color  #fffff0
+
+.color.khaki
+    color  #f0e68c
+
+.color.lavender
+    color  #e6e6fa
+
+.color.lavenderblush
+    color  #fff0f5
+
+.color.lawngreen
+    color  #7cfc00
+
+.color.lemonchiffon
+    color  #fffacd
+
+.color.lightblue
+    color  #add8e6
+
+.color.lightcoral
+    color  #f08080
+
+.color.lightcyan
+    color  #e0ffff
+
+.color.lightgoldenrodyellow
+    color  #fafad2
+
+.color.lightgray
+    color  #d3d3d3
+
+.color.lightgreen
+    color  #90ee90
+
+.color.lightgrey
+    color  #d3d3d3
+
+.color.lightpink
+    color  #ffb6c1
+
+.color.lightsalmon
+    color  #ffa07a
+
+.color.lightseagreen
+    color  #20b2aa
+
+.color.lightskyblue
+    color  #87cefa
+
+.color.lightslategray
+    color  #778899
+
+.color.lightslategrey
+    color  #778899
+
+.color.lightsteelblue
+    color  #b0c4de
+
+.color.lightyellow
+    color  #ffffe0
+
+.color.lime
+    color  #00ff00
+
+.color.limegreen
+    color  #32cd32
+
+.color.linen
+    color  #faf0e6
+
+.color.magenta
+    color  #ff00ff
+
+.color.maroon
+    color  #800000
+
+.color.mediumaquamarine
+    color  #66cdaa
+
+.color.mediumblue
+    color  #0000cd
+
+.color.mediumorchid
+    color  #ba55d3
+
+.color.mediumpurple
+    color  #9370db
+
+.color.mediumseagreen
+    color  #3cb371
+
+.color.mediumslateblue
+    color  #7b68ee
+
+.color.mediumspringgreen
+    color  #00fa9a
+
+.color.mediumturquoise
+    color  #48d1cc
+
+.color.mediumvioletred
+    color  #c71585
+
+.color.midnightblue
+    color  #191970
+
+.color.mintcream
+    color  #f5fffa
+
+.color.mistyrose
+    color  #ffe4e1
+
+.color.moccasin
+    color  #ffe4b5
+
+.color.navajowhite
+    color  #ffdead
+
+.color.navy
+    color  #000080
+
+.color.oldlace
+    color  #fdf5e6
+
+.color.olive
+    color  #808000
+
+.color.olivedrab
+    color  #6b8e23
+
+.color.orange
+    color  #ffa500
+
+.color.orangered
+    color  #ff4500
+
+.color.orchid
+    color  #da70d6
+
+.color.palegoldenrod
+    color  #eee8aa
+
+.color.palegreen
+    color  #98fb98
+
+.color.paleturquoise
+    color  #afeeee
+
+.color.palevioletred
+    color  #db7093
+
+.color.papayawhip
+    color  #ffefd5
+
+.color.peachpuff
+    color  #ffdab9
+
+.color.peru
+    color  #cd853f
+
+.color.pink
+    color  #ffc0cb
+
+.color.plum
+    color  #dda0cb
+
+.color.powderblue
+    color  #b0e0e6
+
+.color.purple
+    color  #800080
+
+.color.red
+    color  #ff0000
+
+.color.rosybrown
+    color  #bc8f8f
+
+.color.royalblue
+    color  #4169e1
+
+.color.saddlebrown
+    color  #8b4513
+
+.color.salmon
+    color  #fa8072
+
+.color.sandybrown
+    color  #f4a460
+
+.color.seagreen
+    color  #2e8b57
+
+.color.seashell
+    color  #fff5ee
+
+.color.sienna
+    color  #a0522d
+
+.color.silver
+    color  #c0c0c0
+
+.color.skyblue
+    color  #87ceeb
+
+.color.slateblue
+    color  #6a5acd
+
+.color.slategray
+    color  #778090
+
+.color.slategrey
+    color  #778090
+
+.color.snow
+    color  #fffffa
+
+.color.springgreen
+    color  #00ff7f
+
+.color.steelblue
+    color  #4682b4
+
+.color.tan
+    color  #d2b48c
+
+.color.teal
+    color  #008080
+
+.color.thistle
+    color  #d8bfd8
+
+.color.tomato
+    color  #ff6347
+
+.color.turquoise
+    color  #40e0d0
+
+.color.violet
+    color  #ee82ee
+
+.color.wheat
+    color  #f5deb3
+
+.color.white
+    color  #ffffff
+
+.color.whitesmoke
+    color  #f5f5f5
+
+.color.yellow
+    color  #ffff00
+
+.color.yellowgreen
+    color  #9acd05
+
+
+.bck.aliceblue
+    background-color  #f0f8ff
+
+.bck.antiquewhite
+    background-color  #faebd7
+
+.bck.aqua
+    background-color  #00ffff
+
+.bck.aquamarine
+    background-color  #7fffd4
+
+.bck.azure
+    background-color  #f0ffff
+
+.bck.beige
+    background-color  #f5f5dc
+
+.bck.bisque
+    background-color  #ffe4c4
+
+.bck.black
+    background-color  #000000
+
+.bck.blanchedalmond
+    background-color  #ffebcd
+
+.bck.blue
+    background-color  #0000ff
+
+.bck.blueviolet
+    background-color  #8a2be2
+
+.bck.brown
+    background-color  #a52a2a
+
+.bck.burlywood
+    background-color  #deb887
+
+.bck.cadetblue
+    background-color  #5f9ea0
+
+.bck.chartreuse
+    background-color  #7fff00
+
+.bck.chocolate
+    background-color  #d2691e
+
+.bck.coral
+    background-color  #ff7f50
+
+.bck.cornflowerblue
+    background-color  #6495ed
+
+.bck.cornsilk
+    background-color  #fff8dc
+
+.bck.crimson
+    background-color  #dc143c
+
+.bck.cyan
+    background-color  #00ffff
+
+.bck.darkblue
+    background-color  #00008b
+
+.bck.darkcyan
+    background-color  #008b8b
+
+.bck.darkgoldenrod
+    background-color  #b8840b
+
+.bck.darkgray
+    background-color  #a9a9a9
+
+.bck.darkgreen
+    background-color  #006400
+
+.bck.darkgrey
+    background-color  #a9a9a9
+
+.bck.darkkhaki
+    background-color  #bdb76b
+
+.bck.darkmagenta
+    background-color  #8b008b
+
+.bck.darkolivegreen
+    background-color  #556b2f
+
+.bck.darkorange
+    background-color  #ff8c00
+
+.bck.darkorchid
+    background-color  #9932cc
+
+.bck.darkred
+    background-color  #8b0000
+
+.bck.darksalmon
+    background-color  #e9967a
+
+.bck.darkseagreen
+    background-color  #8fbc8f
+
+.bck.darkslateblue
+    background-color  #483d8b
+
+.bck.darkslategray
+    background-color  #2f4f4f
+
+.bck.darkslategrey
+    background-color  #2f4f4f
+
+.bck.darkturquoise
+    background-color  #00ced1
+
+.bck.darkviolet
+    background-color  #9400d3
+
+.bck.deeppink
+    background-color  #ff1493
+
+.bck.deepskyblue
+    background-color  #00bfff
+
+.bck.dimgray
+    background-color  #696969
+
+.bck.dimgrey
+    background-color  #696969
+
+.bck.dodgerblue
+    background-color  #1e90ff
+
+.bck.firebrick
+    background-color  #b22222
+
+.bck.floralwhite
+    background-color  #fffff0
+
+.bck.forestgreen
+    background-color  #228b22
+
+.bck.fuchsia
+    background-color  #ff00ff
+
+.bck.gainsboro
+    background-color  #dcdcdc
+
+.bck.ghostwhite
+    background-color  #f8f8ff
+
+.bck.gold
+    background-color  #ffd700
+
+.bck.goldenrod
+    background-color  #daa520
+
+.bck.gray
+    background-color  #808080
+
+.bck.green
+    background-color  #008000
+
+.bck.greenyellow
+    background-color  #adff2f
+
+.bck.grey
+    background-color  #808080
+
+.bck.honeydew
+    background-color  #f0fff0
+
+.bck.hotpink
+    background-color  #ff69b4
+
+.bck.indianred
+    background-color  #cd5c5c
+
+.bck.indigo
+    background-color  #4b0082
+
+.bck.ivory
+    background-color  #fffff0
+
+.bck.khaki
+    background-color  #f0e68c
+
+.bck.lavender
+    background-color  #e6e6fa
+
+.bck.lavenderblush
+    background-color  #fff0f5
+
+.bck.lawngreen
+    background-color  #7cfc00
+
+.bck.lemonchiffon
+    background-color  #fffacd
+
+.bck.lightblue
+    background-color  #add8e6
+
+.bck.lightcoral
+    background-color  #f08080
+
+.bck.lightcyan
+    background-color  #e0ffff
+
+.bck.lightgoldenrodyellow
+    background-color  #fafad2
+
+.bck.lightgray
+    background-color  #d3d3d3
+
+.bck.lightgreen
+    background-color  #90ee90
+
+.bck.lightgrey
+    background-color  #d3d3d3
+
+.bck.lightpink
+    background-color  #ffb6c1
+
+.bck.lightsalmon
+    background-color  #ffa07a
+
+.bck.lightseagreen
+    background-color  #20b2aa
+
+.bck.lightskyblue
+    background-color  #87cefa
+
+.bck.lightslategray
+    background-color  #778899
+
+.bck.lightslategrey
+    background-color  #778899
+
+.bck.lightsteelblue
+    background-color  #b0c4de
+
+.bck.lightyellow
+    background-color  #ffffe0
+
+.bck.lime
+    background-color  #00ff00
+
+.bck.limegreen
+    background-color  #32cd32
+
+.bck.linen
+    background-color  #faf0e6
+
+.bck.magenta
+    background-color  #ff00ff
+
+.bck.maroon
+    background-color  #800000
+
+.bck.mediumaquamarine
+    background-color  #66cdaa
+
+.bck.mediumblue
+    background-color  #0000cd
+
+.bck.mediumorchid
+    background-color  #ba55d3
+
+.bck.mediumpurple
+    background-color  #9370db
+
+.bck.mediumseagreen
+    background-color  #3cb371
+
+.bck.mediumslateblue
+    background-color  #7b68ee
+
+.bck.mediumspringgreen
+    background-color  #00fa9a
+
+.bck.mediumturquoise
+    background-color  #48d1cc
+
+.bck.mediumvioletred
+    background-color  #c71585
+
+.bck.midnightblue
+    background-color  #191970
+
+.bck.mintcream
+    background-color  #f5fffa
+
+.bck.mistyrose
+    background-color  #ffe4e1
+
+.bck.moccasin
+    background-color  #ffe4b5
+
+.bck.navajowhite
+    background-color  #ffdead
+
+.bck.navy
+    background-color  #000080
+
+.bck.oldlace
+    background-color  #fdf5e6
+
+.bck.olive
+    background-color  #808000
+
+.bck.olivedrab
+    background-color  #6b8e23
+
+.bck.orange
+    background-color  #ffa500
+
+.bck.orangered
+    background-color  #ff4500
+
+.bck.orchid
+    background-color  #da70d6
+
+.bck.palegoldenrod
+    background-color  #eee8aa
+
+.bck.palegreen
+    background-color  #98fb98
+
+.bck.paleturquoise
+    background-color  #afeeee
+
+.bck.palevioletred
+    background-color  #db7093
+
+.bck.papayawhip
+    background-color  #ffefd5
+
+.bck.peachpuff
+    background-color  #ffdab9
+
+.bck.peru
+    background-color  #cd853f
+
+.bck.pink
+    background-color  #ffc0cb
+
+.bck.plum
+    background-color  #dda0cb
+
+.bck.powderblue
+    background-color  #b0e0e6
+
+.bck.purple
+    background-color  #800080
+
+.bck.red
+    background-color  #ff0000
+
+.bck.rosybrown
+    background-color  #bc8f8f
+
+.bck.royalblue
+    background-color  #4169e1
+
+.bck.saddlebrown
+    background-color  #8b4513
+
+.bck.salmon
+    background-color  #fa8072
+
+.bck.sandybrown
+    background-color  #f4a460
+
+.bck.seagreen
+    background-color  #2e8b57
+
+.bck.seashell
+    background-color  #fff5ee
+
+.bck.sienna
+    background-color  #a0522d
+
+.bck.silver
+    background-color  #c0c0c0
+
+.bck.skyblue
+    background-color  #87ceeb
+
+.bck.slateblue
+    background-color  #6a5acd
+
+.bck.slategray
+    background-color  #778090
+
+.bck.slategrey
+    background-color  #778090
+
+.bck.snow
+    background-color  #fffffa
+
+.bck.springgreen
+    background-color  #00ff7f
+
+.bck.steelblue
+    background-color  #4682b4
+
+.bck.tan
+    background-color  #d2b48c
+
+.bck.teal
+    background-color  #008080
+
+.bck.thistle
+    background-color  #d8bfd8
+
+.bck.tomato
+    background-color  #ff6347
+
+.bck.turquoise
+    background-color  #40e0d0
+
+.bck.violet
+    background-color  #ee82ee
+
+.bck.wheat
+    background-color  #f5deb3
+
+.bck.white
+    background-color  #ffffff
+
+.bck.whitesmoke
+    background-color  #f5f5f5
+
+.bck.yellow
+    background-color  #ffff00
+
+.bck.yellowgreen
+    background-color  #9acd05

--- a/sources/stylesheets/tuktuk.layout.styl
+++ b/sources/stylesheets/tuktuk.layout.styl
@@ -44,8 +44,6 @@ body
         margin-right: 0
 
   & > section
-    &.padding
-      padding: (AIR * 4) 0
     &.landing
       padding: (AIR * 6) 0
       & h1

--- a/sources/stylesheets/tuktuk.table.styl
+++ b/sources/stylesheets/tuktuk.table.styl
@@ -9,7 +9,7 @@ table
     padding: 0.5em 0.5em
 
   &.hoverable tr:hover td
-  	background-color: rgba(55, 130, 130. 0.3)
+    background-color: rgba(55, 130, 130, 0.3)
 
   & th, td.highlight
     font-weight: bold

--- a/sources/stylesheets/tuktuk.table.styl
+++ b/sources/stylesheets/tuktuk.table.styl
@@ -4,7 +4,12 @@ table
   margin: 1em 0
   width: 100%
   border-spacing: 0.1em
+
   & td, th
     padding: 0.5em 0.5em
+
+  &.hoverable tr:hover td
+  	background-color: rgba(55, 130, 130. 0.3)
+
   & th, td.highlight
     font-weight: bold


### PR DESCRIPTION
The major feature of this pull request is a set of named colours. Now you can use, for example, `.bck.lightblue` class to set the `background-color: #add8e6;` property or `.text.color.lightblue` to set the equivalent text color.

The next feature is `.hoverable` class. If you add one to a table, its rows will be colored with `#dedede` color on hover. 

_Note:_ one needs to be refactored to use color, depending on the theme colors or table row color.

And the last API change is removed top padding for `<secion>` tag. This padding added some uglyness if you have used it so i just thought _"Hey! I do not want to override this rule any time i use this framework! I don't need others to see this though!"_ and removed it:

![screen1](https://f.cloud.github.com/assets/137882/907467/dd5c4c8c-fd3d-11e2-90b4-dc0c02c86f24.jpg)

Other change is `README` additions related to the `package.json` file. I created one to make the setup process more... Smooth.
