### PR TITLE
Emulate native alert, confirm and prompt using Modals

### DIFF
--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -24,11 +24,60 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     @
 
   alert = (message = "") ->
-    lock.addClass("active").show()
-    @_hideAnyModal()
-    modal = tk.dom("[data-tuktuk=modal][data-modal=alert")
+    modal = tk.dom("[data-tuktuk=modal][data-modal=alert]")
     text  = modal.find "#text"
     text.html message
+
+    modal.find("button.success").on "click.Modal.alert", ->
+      hide()
+
+    lock.addClass("active").show()
+    @_hideAnyModal()
+    modal.addClass "active"
+    @
+
+  confirm = (message = "", true_cb, false_cb) ->
+    modal = tk.dom("[data-tuktuk=modal][data-modal=confirm]")
+    text  = modal.find "#text"
+    accept_button = modal.find "button.success"
+    cancel_button = modal.find "button.alert"
+
+    doCallback = (callback) ->
+      hide()
+      accept_button.unbind "click.Modal.confirm"
+      cancel_button.unbind "click.Modal.confirm"
+      if callback then setTimeout callback, 250
+
+    text.html message
+    accept_button.on "click.Modal.confirm", -> doCallback true_cb
+    cancel_button.on "click.Modal.confirm", -> doCallback false_cb
+
+    lock.addClass("active").show()
+    @_hideAnyModal()
+    modal.addClass "active"
+    @
+
+  prompt = (message = "", callback) ->
+    modal = tk.dom("[data-tuktuk=modal][data-modal=prompt]")
+    text  = modal.find "#text"
+    content = modal.find "#content"
+    accept_button = modal.find "button.success"
+    cancel_button = modal.find "button.alert"
+
+    text.html message
+    accept_button.on "click.Modal.prompt", -> 
+      content = content.val()      
+      hide()
+      accept_button.unbind "click.Modal.prompt"
+      if callback then setTimeout ->
+        callback(content)
+      , 250
+
+    cancel_button.on "click.Modal.prompt", -> hide()
+    content.val ""
+
+    lock.addClass("active").show()
+    @_hideAnyModal()
     modal.addClass "active"
     @
 
@@ -51,7 +100,7 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     tk.dom("[data-tuktuk-modal]").on "click", ->
       TukTuk.Modal.show(tk.dom(this).attr('data-tuktuk-modal'))
 
-    loading = """
+    loading_template = """
       <div data-tuktuk="lock" data-loading="false">
         <div class="loading"></div>
       </div>
@@ -63,20 +112,57 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
         </header>
         <article id="text" class="text big"></article>
         <footer>
-          <button data-modal="close" class="button large theme on-right margin-bottom">Accept</button>            
+          <button class="button large success on-right margin-bottom">
+            <span class="icon ok"></span>
+          </button>
         </footer>
       </div>
       """
+
     prompt_template = """
+      <div data-tuktuk="modal" data-modal="prompt" class="column_5">
+        <header class="bck alert">
+          <h4 class="text thin inline">Alert</h4>            
+        </header>
+        <article class="text big">
+          <form>
+            <label for="content" id="text"/>
+            <input type="text" id="content"/>
+          </form>
+        </article>
+        <footer>
+          <button class="button large alert on-right margin-bottom">
+            <span class="icon remove"></span>
+          </button>
+          <button class="button large success on-right margin-bottom margin-right">
+            <span class="icon ok"></span>
+          </button>          
+        </footer>        
+      </div>
       """
+
     confirm_template = """
+      <div data-tuktuk="modal" data-modal="confirm" class="column_5">
+        <header class="bck alert">
+          <h4 class="text thin inline">Confirm</h4>            
+        </header>
+        <article id="text" class="text big"></article>
+        <footer>
+          <button class="button large alert on-right margin-bottom">
+            <span class="icon remove"></span>
+          </button>
+          <button class="button large success on-right margin-bottom margin-right">
+            <span class="icon ok"></span>
+          </button>
+        </footer>
+      </div>
       """
 
     tk.dom(document.body).append """
       #{alert_template}
       #{prompt_template}
       #{confirm_template}
-      #{loading}
+      #{loading_template}
       """
 
     tk.dom("[data-tuktuk=lock]").on "click", (event) ->
@@ -90,3 +176,5 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
   hide    : hide
   loading : loading
   alert   : alert
+  confirm : confirm
+  prompt  : prompt

--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -1,6 +1,6 @@
 window.TukTuk.Modal = do (tk = TukTuk) ->
 
-  lock = undefined
+  lock  = undefined
   modal = undefined
 
   ###
@@ -23,6 +23,15 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     , 250
     @
 
+  alert = (message = "") ->
+    lock.addClass("active").show()
+    @_hideAnyModal()
+    modal = tk.dom("[data-tuktuk=modal][data-modal=alert")
+    text  = modal.find "#text"
+    text.html message
+    modal.addClass "active"
+    @
+
   ###
       @loading: Describe method
   ###
@@ -42,11 +51,34 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     tk.dom("[data-tuktuk-modal]").on "click", ->
       TukTuk.Modal.show(tk.dom(this).attr('data-tuktuk-modal'))
 
-    tk.dom(document.body).append """
+    loading = """
       <div data-tuktuk="lock" data-loading="false">
         <div class="loading"></div>
       </div>
       """
+    alert_template = """
+      <div data-tuktuk="modal" data-modal="alert" class="column_5">
+        <header class="bck alert">
+          <h4 class="text thin inline">Alert</h4>            
+        </header>
+        <article id="text" class="text big"></article>
+        <footer>
+          <button data-modal="close" class="button large theme on-right margin-bottom">Accept</button>            
+        </footer>
+      </div>
+      """
+    prompt_template = """
+      """
+    confirm_template = """
+      """
+
+    tk.dom(document.body).append """
+      #{alert_template}
+      #{prompt_template}
+      #{confirm_template}
+      #{loading}
+      """
+
     tk.dom("[data-tuktuk=lock]").on "click", (event) ->
       loading = lock.attr("data-loading")
       TukTuk.Modal.hide() unless event.target is modal or loading is "true"
@@ -54,6 +86,7 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     lock = tk.dom("[data-tuktuk=lock]").first()
   )()
 
-  show: show
-  hide: hide
-  loading: loading
+  show    : show
+  hide    : hide
+  loading : loading
+  alert   : alert


### PR DESCRIPTION
Hi! 
I've tried to implement the functionality of the alert, confirm and prompt native functions using the Modal class.

The results are handled using callbacks, trying to emulate the native ones, as I explain bellow. In all of them the `message` is optional, falling back to `""` if empty:
#### Alert

It's called with `TukTuk.Modal.alert(message)`
This has no callback, just like the native one. 
#### Confirm

It's called with `TukTuk.Modal.confirm(message, trueCallback, falseCallback)`
Will fire the appropiate callback depending on the user's response. Of course, none of the callback's is required.
#### Prompt

It's called with `TukTuk.Modal.prompt(message, callback)`
This will fire the callback giving as an argument the text the user had previously typed. If the user cancels the Modal no callback will be fired.

This is mostly an attemp to give the applications and websites using this framework more visual consistency and to facilitate the development process not having to write them all the times! 

Let me know what do you think! :+1: 
