### PR TITLE
Possible fix for #34, pass a parameter to `box-flex`

### DIFF
--- a/sources/stylesheets/tuktuk.layout.styl
+++ b/sources/stylesheets/tuktuk.layout.styl
@@ -57,7 +57,7 @@ body
         & *
           float: left
         & input
-          box-flex()
+          box-flex(1)
           width: 85%
           border-right: 0
           margin-top: 0


### PR DESCRIPTION
With no parameter on `box-flex` the resulting -webkit-box-flex and similar
parameters have no value, which does ot validate as proper CSS.

This is a potential fix for #34
