### PR TITLE
Modal fix

### DIFF
--- a/sources/tuktuk.accordion.coffee
+++ b/sources/tuktuk.accordion.coffee
@@ -1,11 +1,16 @@
 window.TukTuk.Accordion = do (tk = TukTuk) ->
 
-  init: do ->    
+  init = ->    
     tk.dom("[data-tuktuk=accordion]").each (index, element) ->
       accordion = tk.dom element
-      activator = accordion.find("[data-accordion=activator]").first()
+      activator = accordion.find("> [data-accordion=activator]").first()
       activator.on "click", (event) ->
         if accordion.hasClass "active"
           accordion.removeClass "active"
         else 
           accordion.addClass "active"
+
+  _Instance : 
+    init()
+
+  init : init

--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -64,6 +64,9 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     accept_button = modal.find "button.success"
     cancel_button = modal.find "button.alert"
 
+    accept_button = modal.unbind "click.Modal.prompt"
+    cancel_button = modal.unbind "click.Modal.prompt"
+
     text.html message
     accept_button.on "click.Modal.prompt", ->
       content = content.val()

--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -1,12 +1,14 @@
 window.TukTuk.Modal = do (tk = TukTuk) ->
 
-  lock  = undefined
-  modal = undefined
+  lock       = undefined
+  modal      = undefined
+  disposable = true
 
   ###
       @todo: Describe method
   ###
-  show = (modal_id) ->
+  show = (modal_id, allow_dismiss=true) ->
+    disposable = allow_dismiss
     lock.addClass("active").show()
     @_hideAnyModal()
     modal = tk.dom("[data-tuktuk=modal]##{modal_id}").addClass "active"
@@ -24,6 +26,7 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     @
 
   alert = (message = "") ->
+    disposable = true
     modal = tk.dom("[data-tuktuk=modal][data-modal=alert]")
     text  = modal.find "#text"
     text.html message
@@ -37,6 +40,7 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     @
 
   confirm = (message = "", true_cb, false_cb) ->
+    disposable = false
     modal = tk.dom("[data-tuktuk=modal][data-modal=confirm]")
     text  = modal.find "#text"
     accept_button = modal.find "button.success"
@@ -58,6 +62,7 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     @
 
   prompt = (message = "", callback) ->
+    disposable = false
     modal = tk.dom("[data-tuktuk=modal][data-modal=prompt]")
     text  = modal.find "#text"
     content = modal.find "#content"
@@ -166,6 +171,11 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
       #{confirm_template}
       #{loading_template}
       """
+
+    tk.dom("[data-tuktuk=lock]").on "click", (event) ->
+      loading = lock.attr("data-loading")
+      unless event.target is modal or loading is "true" or not disposable
+        TukTuk.Modal.hide() 
 
     lock = tk.dom("[data-tuktuk=lock]").first()
 

--- a/sources/tuktuk.modal.coffee
+++ b/sources/tuktuk.modal.coffee
@@ -64,14 +64,13 @@ window.TukTuk.Modal = do (tk = TukTuk) ->
     accept_button = modal.find "button.success"
     cancel_button = modal.find "button.alert"
 
-    accept_button = modal.unbind "click.Modal.prompt"
-    cancel_button = modal.unbind "click.Modal.prompt"
+    accept_button.unbind "click.Modal.prompt"
+    cancel_button.unbind "click.Modal.prompt"
 
     text.html message
-    accept_button.on "click.Modal.prompt", ->
-      content = content.val()
-      hide()
-      accept_button.unbind "click.Modal.prompt"
+    accept_button.on "click.Modal.prompt", -> 
+      content = content.val()      
+      hide()      
       if callback then setTimeout ->
         callback(content)
       , 250


### PR DESCRIPTION
Fix confirm bug when dismissing the modal by clicking outside that caused the event to be fired as many times as the modal had been shown.

Now there is a new feature to intentionally allow or not a modal to be disposable by clicking outside.

Also add the option to initialize the accordions at any time
